### PR TITLE
Only paginate collection results if paginator is specified

### DIFF
--- a/lib/jsonapi/utils.rb
+++ b/lib/jsonapi/utils.rb
@@ -91,7 +91,8 @@ module JSONAPI
     def result_options(options)
       hash = {}
 
-      if JSONAPI.configuration.top_level_links_include_pagination
+      if JSONAPI.configuration.default_paginator != :none &&
+          JSONAPI.configuration.top_level_links_include_pagination
         hash[:pagination_params] = pagination_params(options)
       end
 


### PR DESCRIPTION
`JSONAPI::Resources` by default [configures the default paginator to `:none`](https://github.com/cerebris/jsonapi-resources#configuration), but `config.top_level_links_include_pagination = true`. 

Doesn't seem to make sense to me to try and paginate based on whether someone wants top level links to include pagination, but rather based on whether there's any paginator configured.

Thanks! 😄 
