### PR TITLE
Grab id for exception message from request object

### DIFF
--- a/lib/jsonapi/utils.rb
+++ b/lib/jsonapi/utils.rb
@@ -42,8 +42,7 @@ module JSONAPI
     end
 
     def jsonapi_render_not_found(exception)
-      setup_request
-      id = exception.message.match(/=(\d+)/)[1]
+      id = setup_request.instance_variable_get("@id")
       jsonapi_render_errors(JSONAPI::Exceptions::RecordNotFound.new(id))
     end
 


### PR DESCRIPTION
No need for the regex as the desired `id` attribute is available as an instance variable on the request object.