### PR TITLE
Don't try to add jsonapi_serialize as helper unless it's possible to do so

### DIFF
--- a/lib/jsonapi/utils.rb
+++ b/lib/jsonapi/utils.rb
@@ -4,7 +4,9 @@ require 'jsonapi/utils/exceptions'
 module JSONAPI
   module Utils
     def self.included(base)
-      base.helper_method :jsonapi_serialize
+      if base.respond_to?(:helper_method)
+        base.helper_method :jsonapi_serialize
+      end
     end
 
     def jsonapi_render(options)


### PR DESCRIPTION
## Description

From: https://github.com/plataformatec/devise/pull/3732

> Currently Devise::Controllers::Helpers depends on #helper_method, which is defined inside AbstractController::Helpers. This module is included in ActionController::Base, but it is not included by default in ActionController::Metal.

> #helper_method is not essential to the functionality of the methods inside Devise::Controllers::Helpers, so this PR wraps all Devise #helper_method calls with respond_to?(:helper_method) checks.

This console output elucidates the issue:

```ruby
[14] pry(main)> ActionController::Base.ancestors.map(&:to_s).grep(/Helpers/)
=> ["ActionDispatch::Routing::RouteSet::MountedHelpers", "ActionController::Helpers", "AbstractController::Helpers"]
[15] pry(main)> ApplicationController.ancestors.map(&:to_s).grep(/Helpers/)
=> ["ActionDispatch::Routing::RouteSet::MountedHelpers"]
```

## Background

* Rails 5.0.0.rc1
* `RAILS_ENV=test` (was trying to run a new API's first request specs)