### PR TITLE
Don't add git dep in gemspec

### DIFF
--- a/jsonapi-utils.gemspec
+++ b/jsonapi-utils.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/b2beauty/jsonapi-utils'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = Dir.glob("{bin,lib}/**/*") + %w(LICENSE.txt README.md CODE_OF_CONDUCT.md)
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']


### PR DESCRIPTION
## Description

Introducing `git` as a dependency in the `<gem-name>.gemspec` file introduces a problem for those of us isolating our applications within Docker containers that don't otherwise need `git`.