### PR TITLE
Setup and check request before action executes

### DIFF
--- a/jsonapi-utils.gemspec
+++ b/jsonapi-utils.gemspec
@@ -23,10 +23,9 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rspec-rails', '~> 3.1'
-  spec.add_development_dependency 'smart_rspec', '~> 0.1.4'
   spec.add_development_dependency 'sqlite3'
-  spec.add_development_dependency 'factory_girl', '~> 4.5'
-  spec.add_development_dependency 'jsonapi-resources', '~> 0.7.0'
   spec.add_development_dependency 'rails', '~> 4.2'
+  spec.add_development_dependency 'rspec-rails', '~> 3.1'
+  spec.add_development_dependency 'factory_girl', '~> 4.5'
+  spec.add_development_dependency 'smart_rspec', '~> 0.1.4'
 end

--- a/lib/jsonapi/utils.rb
+++ b/lib/jsonapi/utils.rb
@@ -23,8 +23,9 @@ module JSONAPI
     end
 
     def jsonapi_render_errors(exception)
-      error = jsonapi_format_errors(exception)
-      render json: { errors: error.errors }, status: error.code
+      result = jsonapi_format_errors(exception)
+      errors = result.errors
+      render json: { errors: errors }, status: errors.first.status
     end
 
     def jsonapi_format_errors(exception)

--- a/lib/jsonapi/utils/version.rb
+++ b/lib/jsonapi/utils/version.rb
@@ -1,5 +1,5 @@
 module JSONAPI
   module Utils
-    VERSION = '0.4.3'
+    VERSION = '0.4.4'
   end
 end

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 require 'rspec/expectations'
 
 describe PostsController, type: :controller do
+  include_context 'JSON API headers'
+
   before(:all) { FactoryGirl.create_list(:post, 3) }
 
   let(:fields)        { (PostResource.fetchable_fields - %i(id author)).map(&:to_s) }

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -262,10 +262,10 @@ describe UsersController, type: :controller do
 
     context 'when validation fails' do
       it 'render a 422 response' do
-        user_params[:data][:attributes].merge!(first_name: '')
+        user_params[:data][:attributes].merge!(first_name: nil)
         expect { post :create, user_params }.to change(User, :count).by(0)
         expect(response).to have_http_status :unprocessable_entity
-        expect(error['title']).to eq('Impossible to change this User')
+        expect(error['title']).to eq('Can\'t change this User')
         expect(error['code']).to eq(125)
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -97,4 +97,3 @@ TestApp.routes.draw do
   get :index_with_hash, to: 'posts#index_with_hash'
   get :show_with_hash,  to: 'posts#show_with_hash'
 end
-

--- a/spec/support/controllers.rb
+++ b/spec/support/controllers.rb
@@ -1,3 +1,5 @@
+require 'support/exceptions'
+
 class BaseController < JSONAPI::ResourceController
   include JSONAPI::Utils
   protect_from_forgery with: :null_session
@@ -38,7 +40,7 @@ class PostsController < BaseController
     jsonapi_render json: new_post, status: :created
   end
 
-  private
+  protected
 
   def load_user
     @user = User.find(params[:user_id])
@@ -48,13 +50,29 @@ end
 class UsersController < BaseController
   # GET /users
   def index
-    @users = User.all
-    jsonapi_render json: @users
+    users = User.all
+    jsonapi_render json: users
   end
 
   # GET /users/:id
   def show
-    @user = User.find(params[:id])
-    jsonapi_render json: @user
+    user = User.find(params[:id])
+    jsonapi_render json: user
+  end
+
+  # POST /users
+  def create
+    user = User.new(user_params)
+    if user.save
+      jsonapi_render json: user, status: :created
+    else
+      jsonapi_render_errors ::Exceptions::ActiveRecordError.new(user)
+    end
+  end
+
+  protected
+
+  def user_params
+    params.require(:data).require(:attributes).permit(:first_name, :last_name, :admin)
   end
 end

--- a/spec/support/exceptions.rb
+++ b/spec/support/exceptions.rb
@@ -1,0 +1,17 @@
+module Exceptions
+  class ActiveRecordError < ::JSONAPI::Exceptions::Error
+    attr_accessor :object
+
+    def initialize(object)
+      @object = object
+    end
+
+    def errors
+      [JSONAPI::Error.new(
+        code: 125,
+        status: :unprocessable_entity,
+        title: "Impossible to change this #{@object.class.name}",
+        detail: @object.errors)]
+    end
+  end
+end

--- a/spec/support/exceptions.rb
+++ b/spec/support/exceptions.rb
@@ -10,7 +10,7 @@ module Exceptions
       [JSONAPI::Error.new(
         code: 125,
         status: :unprocessable_entity,
-        title: "Impossible to change this #{@object.class.name}",
+        title: "Can't change this #{@object.class.name}",
         detail: @object.errors)]
     end
   end

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -14,6 +14,7 @@ ActiveRecord::Schema.define do
   create_table :users, force: true do |t|
     t.string   :first_name
     t.string   :last_name
+    t.boolean  :admin
     t.timestamps null: false
   end
 end

--- a/spec/support/shared/jsonapi_request.rb
+++ b/spec/support/shared/jsonapi_request.rb
@@ -1,0 +1,8 @@
+shared_context 'JSON API headers' do
+  let(:headers) do
+    { 'Accept'       => 'application/vnd.api+json',
+      'Content-Type' => 'application/vnd.api+json' }
+  end
+
+  before(:each) { request.headers.merge!(headers) }
+end


### PR DESCRIPTION
Fixes #12 

## Problem

Due to a change on how `JSONAPI::Resources` deals with the setup and check of requests around its operations, the methods `JSONAPI::Utils#(setup_request|json_api_(render|serialize))` had to change as well, since the request validation and error rendering that once were handled by `JR` now needed to be handled by `JU`.

Unfortunately the implementation caused a bug when dealing with invalid requests:
  1. An invalid request is made (e.g. an invalid param);
  2. Resource is persisted with no errors, since its validation has passed;
  3. When it tries to render the response then an error message is rendered showing the issues with the invalid param. 

## Fix

Now it sets up and checks the request before the action executes. This makes much more sense than validating the request after the actual operation is complete.

- [x] Set up and validate the request before action;
- [x] Write specs. 