### PR TITLE
Update jsonapi-resources runtime version to 0.8.0.beta2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 env:
   - 'RAILS_VERSION=4.1.0'
   - 'RAILS_VERSION=4.2.0'
+  - 'RAILS_VERSION=5.0.0'
 rvm:
   - 2.2
 before_install: gem install bundler -v 1.10.4

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Support:
 Add these lines to your application's Gemfile:
 
 ```ruby
-gem 'jsonapi-utils', '~> 0.4.6' # or '0.5.0.beta1' for Rails 5
+gem 'jsonapi-utils', '~> 0.4.6' # or '0.5.0.beta2' for Rails 5
 ```
 
 And then execute:

--- a/README.md
+++ b/README.md
@@ -38,13 +38,19 @@ Simple yet powerful way to get your Rails API compliant with [JSON API](http://j
 
 Support:
 
-* Ruby ~> 2.0 with Rails ~> 4.0;
-* Ruby ~> 2.1 with Rails 5.
+* Ruby => 2.0 with Rails ~> 4.0;
+* Ruby => 2.2.2 with Rails 5.
 
-Add these lines to your application's Gemfile:
+For Rails 4.x add this to your application's Gemfile:
 
 ```ruby
-gem 'jsonapi-utils', '~> 0.4.6' # or '0.5.0.beta2' for Rails 5
+gem 'jsonapi-utils', '~> 0.4.6'
+```
+
+For Rails 5, specify the beta version in the Gemfile:
+
+```ruby
+gem 'jsonapi-utils', '0.5.0.beta2'
 ```
 
 And then execute:

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ Simple yet powerful way to get your Rails API compliant with [JSON API](http://j
 
 Support:
 
-* Ruby => 2.0 with Rails ~> 4.0;
-* Ruby => 2.2.2 with Rails 5.
+* Ruby 2.x with Rails 4.x
+* Ruby 2.2.2+ with Rails 5
 
 For Rails 4.x add this to your application's Gemfile:
 

--- a/jsonapi-utils.gemspec
+++ b/jsonapi-utils.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'jsonapi-resources', '0.8.0.beta1'
+  spec.add_runtime_dependency 'jsonapi-resources', '0.8.0.beta2'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/lib/jsonapi/utils/version.rb
+++ b/lib/jsonapi/utils/version.rb
@@ -1,5 +1,5 @@
 module JSONAPI
   module Utils
-    VERSION = '0.5.0.beta1'.freeze
+    VERSION = '0.5.0.beta2'.freeze
   end
 end


### PR DESCRIPTION
The goal of these commits is to add support for [jsonapi-resources v0.8.0.beta2](https://github.com/cerebris/jsonapi-resources/tree/v0.8.0.beta2).

This includes:

* Updating the runtime dependency version
* Bumping this gem a beta version
* Updating the README